### PR TITLE
Add a command to look up manpages

### DIFF
--- a/cogs/manpage.py
+++ b/cogs/manpage.py
@@ -67,7 +67,8 @@ class ManPageCog:
         parsed = parse(query)
         if parsed:
             await ctx.send(f"https://linux.die.net/man/{parsed[1]}/{parsed[0]}")
-        await ctx.send("Couldn't parse that input. Try something like `echo(1)`, or `ping 8`. The default section number is 1.")
+        else:
+            await ctx.send("Couldn't parse that input. Try something like `echo(1)`, or `ping 8`. The default section number is 1.")
 
 # add this cog to the bot
 def setup(bot):

--- a/cogs/manpage.py
+++ b/cogs/manpage.py
@@ -15,8 +15,6 @@ def lookup_manpage_section(name: str) -> int:
 
     >>> lookup_manpage_section("ping")
     8
-    >>> lookup_manpage_section("socket")
-    2
     >>> lookup_manpage_section("aaaaaaa")
     1
     >>> lookup_manpage_section("invalid")

--- a/cogs/manpage.py
+++ b/cogs/manpage.py
@@ -2,7 +2,7 @@ import discord
 from discord.ext import commands
 import re
 
-parse_regex = """^\s*([A-Za-z0-9\_\-]+)(?:(?:\w*\(*)([1-8])(?:[\s]*\)*))?\s*$"""
+parse_regex = r"^\s*([A-Za-z0-9\_\-]+)(?:(?:\s*\(?)([1-8])\)?)?\s*$"
 
 def parse(query: str) -> tuple:
     """
@@ -15,15 +15,15 @@ def parse(query: str) -> tuple:
     Does not handle non numeric categories.
 
     >>> parse("echo(1)")
-    ("echo", 1)
+    ('echo', 1)
     >>> parse("echo")
-    ("echo", 1)
+    ('echo', 1)
     >>> parse("     echo    ")
-    ("echo", 1)
+    ('echo', 1)
     >>> parse("     echo    2")
-    ("echo", 2)
+    ('echo', 2)
     >>> parse("   aaaa    8")
-    ("aaaa", 8)
+    ('aaaa', 8)
     >>> parse("invalid -1")
 
     >>> parse("invalid aaa 123")
@@ -35,18 +35,17 @@ def parse(query: str) -> tuple:
     >>> parse("invalid 10")
 
     >>> parse("echo(10)")
+
     """
-    pattern = re.compile(parse_regex, flags=re.IGNORECASE)
+    pattern = re.compile(parse_regex, flags=re.I)
     match = pattern.search(query)
-
-    if match is not None:
-        name, section_number = pattern.group(1, 2)
-
+    if match:
+        name, section_number = match.groups()
         # default to 1
-        if section_number is None:
-            section_number = 1
-        else:
+        if section_number:
             section_number = int(section_number)
+        else:
+            section_number = 1
         return name, section_number
     return None
 

--- a/cogs/manpage.py
+++ b/cogs/manpage.py
@@ -55,7 +55,7 @@ class ManPageCog:
         self.bot = bot
 
     # ping command
-    @commands.cooldown(1, 30, commands.BucketType.user)
+    @commands.cooldown(5, 30, commands.BucketType.user)
     @commands.command('man', aliases=["manpage"])
     async def man(self, ctx, *, query: str):
         """

--- a/cogs/manpage.py
+++ b/cogs/manpage.py
@@ -23,7 +23,7 @@ def parse(query: str) -> tuple:
     >>> parse("     echo    2")
     ("echo", 2)
     >>> parse("   aaaa    8")
-    ("echo", 2)
+    ("aaaa", 8)
     >>> parse("invalid -1")
 
     >>> parse("invalid aaa 123")
@@ -37,28 +37,17 @@ def parse(query: str) -> tuple:
     >>> parse("echo(10)")
     """
     pattern = re.compile(parse_regex, flags=re.IGNORECASE)
-    match = pattern.search
+    match = pattern.search(query)
 
-    name, section_number = pattern.group(1, 2)
+    if match is not None:
+        name, section_number = pattern.group(1, 2)
 
-    # default to 1
-    if section_number is None:
-        section_number = 1
-
-    print('name', name, 'section #', section_number)
-
-    try:
-        if len(split) == 1:
-            # only contains a single term
-            name = split[0]
-        elif len(split) == 2:
-            name = split[0]
+        # default to 1
+        if section_number is None:
+            section_number = 1
+        else:
             section_number = int(section_number)
-            if not (0 < section_number <= 8):
-                return None
         return name, section_number
-    except ValueError:
-        return None
     return None
 
 # setup

--- a/cogs/manpage.py
+++ b/cogs/manpage.py
@@ -104,7 +104,7 @@ class ManPageCog:
         if parsed:
             await ctx.send(f"https://linux.die.net/man/{parsed[1]}/{parsed[0]}")
         else:
-            await ctx.send("Couldn't parse that input. Try something like `echo(1)`, or `ping 8`. The default section number is 1.")
+            await ctx.send("Couldn't parse that input. Try something like `echo(1)`, or `ping`.")
 
 # add this cog to the bot
 def setup(bot):

--- a/cogs/manpage.py
+++ b/cogs/manpage.py
@@ -63,7 +63,11 @@ class ManPageCog:
         https://linux.die.net/
         and replies with the link
         """
-        await ctx.send("todo")
+        # try to parse the query
+        parsed = parse(query)
+        if parsed:
+            await ctx.send(f"https://linux.die.net/man/{parsed[1]}/{parsed[0]}")
+        await ctx.send("Couldn't parse that input. Try something like `echo(1)`, or `ping 8`. The default section number is 1.")
 
 # add this cog to the bot
 def setup(bot):

--- a/cogs/manpage.py
+++ b/cogs/manpage.py
@@ -1,8 +1,44 @@
 import discord
 from discord.ext import commands
 import re
+import subprocess
 
 parse_regex = r"^\s*([A-Za-z0-9\_\-]+)(?:(?:\s*\(?)([1-8])\)?)?\s*$"
+lookup_regex = r"^[\/\w+]+\/man\/man([1-8])\/[\w\.]+$"
+
+def lookup_manpage_section(name: str) -> int:
+    """
+    uses `man -w <name>` to look up the path of the man page,
+    then from that parses the path to get the section
+    number.
+    If not found, defaults to 1.
+
+    >>> lookup_manpage_section("ping")
+    8
+    >>> lookup_manpage_section("socket")
+    2
+    >>> lookup_manpage_section("aaaaaaa")
+    1
+    >>> lookup_manpage_section("invalid")
+    1
+    >>> lookup_manpage_section("very invalid")
+    1
+    >>> lookup_manpage_section("; /usr/bin/xed")
+    1
+
+    """
+    # prevent adding characters that might do bad things
+    protected = "&#?!@;'- |<>"
+    if any(x in name for x in protected):
+        return 1
+    result = subprocess.run(["man", "-w", name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # parse result.stdout
+    pattern = re.compile(lookup_regex, flags=re.I)
+    path = result.stdout.decode()
+    match = pattern.search(path)
+    if match:
+        return int(match.group(1))
+    return 1
 
 def parse(query: str) -> tuple:
     """
@@ -45,7 +81,7 @@ def parse(query: str) -> tuple:
         if section_number:
             section_number = int(section_number)
         else:
-            section_number = 1
+            section_number = lookup_manpage_section(name)
         return name, section_number
     return None
 

--- a/cogs/manpage.py
+++ b/cogs/manpage.py
@@ -1,0 +1,87 @@
+import discord
+from discord.ext import commands
+import re
+
+parse_regex = """^\s*([A-Za-z0-9\_\-]+)(?:(?:\w*\(*)([1-8])(?:[\s]*\)*))?\s*$"""
+
+def parse(query: str) -> tuple:
+    """
+    Parses an input into a pair of the (name, section number)
+
+    Assumes that the default section number is 1.
+
+    If an input is not valid, returns None.
+
+    Does not handle non numeric categories.
+
+    >>> parse("echo(1)")
+    ("echo", 1)
+    >>> parse("echo")
+    ("echo", 1)
+    >>> parse("     echo    ")
+    ("echo", 1)
+    >>> parse("     echo    2")
+    ("echo", 2)
+    >>> parse("   aaaa    8")
+    ("echo", 2)
+    >>> parse("invalid -1")
+
+    >>> parse("invalid aaa 123")
+
+    >>> parse("invalid 0")
+
+    >>> parse("invalid 9")
+    
+    >>> parse("invalid 10")
+
+    >>> parse("echo(10)")
+    """
+    pattern = re.compile(parse_regex, flags=re.IGNORECASE)
+    match = pattern.search
+
+    name, section_number = pattern.group(1, 2)
+
+    # default to 1
+    if section_number is None:
+        section_number = 1
+
+    print('name', name, 'section #', section_number)
+
+    try:
+        if len(split) == 1:
+            # only contains a single term
+            name = split[0]
+        elif len(split) == 2:
+            name = split[0]
+            section_number = int(section_number)
+            if not (0 < section_number <= 8):
+                return None
+        return name, section_number
+    except ValueError:
+        return None
+    return None
+
+# setup
+class ManPageCog:
+    def __init__(self, bot):
+        self.bot = bot
+
+    # ping command
+    @commands.cooldown(1, 30, commands.BucketType.user)
+    @commands.command('man', aliases=["manpage"])
+    async def man(self, ctx, *, query: str):
+        """
+        Tries to look up a manpage on 
+        https://linux.die.net/
+        and replies with the link
+        """
+        await ctx.send("todo")
+
+# add this cog to the bot
+def setup(bot):
+    bot.add_cog(ManPageCog(bot))
+
+# optional, but helpful for testing via the shell
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ with open('config.ini') as config_file:
 print('discordpy')
 print(discord.__version__)
 
-client = commands.Bot(command_prefix='>>', description='https://github.com/Chris-Johnston/CssBot-Py')
+client = commands.Bot(command_prefix='>>', description='https://github.com/Chris-Johnston/CssBot-Py', case_insensitive=True)
 
 # this is where extensions are added by default
 default_extensions = ['cogs.basic',
@@ -35,7 +35,8 @@ default_extensions = ['cogs.basic',
                       'cogs.number_utils',
                       'cogs.hardware_utils',
                       'cogs.analytics',
-                      'cogs.gpa']
+                      'cogs.gpa',
+                      'cogs.manpage']
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -10,12 +10,14 @@ import cogs.basic
 import cogs.courseInfo
 import cogs.number_utils
 import cogs.gpa
+import cogs.manpage
 
 test_modules = [
     cogs.basic,
     cogs.courseInfo,
     cogs.number_utils,
-    cogs.gpa
+    cogs.gpa,
+    cogs.manpage
 ]
 
 def load_tests(tests):


### PR DESCRIPTION
Fix #13 

Adds a command that gets a link to online documentation of linux manpages. If the section number is not specified, tries to look up the section number on the host machine. If this cannot be found, uses a default of 1.