### PR TITLE
Add forbidden glyph game mechanics

### DIFF
--- a/cogs/fifth_glyph.py
+++ b/cogs/fifth_glyph.py
@@ -41,6 +41,19 @@ class FifthGlyphCog(commands.Cog):
                     logger.info(f"Deleted message {message.id}, contained verboten glyph '{g}', contents were '{message.content}'")
                     await message.delete()
 
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload):
+        if payload.channel_id != fifth_glyph_channel_id:
+            return
+        channel = self.bot.get_channel(payload.channel_id)
+        message = await channel.fetch_message(payload.message_id)
+
+        for g in glyphs:
+            if (payload.emoji.is_unicode_emoji() and g in emoji.demojize(payload.emoji.name)) or g in payload.emoji.name:
+                logger.debug(f"reaction is being removed for non cached message: {payload.message_id}")
+                await message.clear_reaction(payload.emoji)
+                return
+
 def setup(bot):
     bot.add_cog(FifthGlyphCog(bot))
 

--- a/cogs/fifth_glyph.py
+++ b/cogs/fifth_glyph.py
@@ -1,0 +1,50 @@
+"""
+Fifth glyph is bad, ban at all costs.
+"""
+import discord
+from discord.ext import commands
+import re
+import logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+# real channel ID
+# fifth_glyph_channel_id = 820535744035553290
+
+# testing channel ID
+fifth_glyph_channel_id = 820549897501540424
+
+glyphs = ['e', 'E', 'ꗋ', 'æ', 'Æ', 'œ', 'Œ', '€', '£', 'ⱻ', 'Ɇ', 'ɇ', 'Ə', 'ǝ', 'ⱸ', 'Ɛ', 'ℇ']
+
+class FifthGlyphCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_raw_message_edit(self, payload):
+        if payload.channel_id != fifth_glyph_channel_id:
+            return
+        logger.debug(f"edit for non cached message: {payload.message_id}")
+        channel = self.bot.get_channel(payload.channel_id)
+        message = await channel.fetch_message(payload.message_id)
+
+        await self.on_message(message)
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        """
+        Audaciously cull the fifth glyph
+        """
+        if message.channel and isinstance(message.channel, discord.TextChannel) and message.channel.id == fifth_glyph_channel_id:
+            for g in glyphs:
+                if g in message.content or any([True for a in message.attachments if g in a.filename]):
+                    logger.info(f"Deleted message {message.id}, contained verboten glyph '{g}', contents were '{message.content}'")
+                    await message.delete()
+
+def setup(bot):
+    bot.add_cog(FifthGlyphCog(bot))
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()
+

--- a/cogs/fifth_glyph.py
+++ b/cogs/fifth_glyph.py
@@ -3,7 +3,7 @@ Fifth glyph is bad, ban at all costs.
 """
 import discord
 from discord.ext import commands
-import re
+import emoji
 import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -37,7 +37,7 @@ class FifthGlyphCog(commands.Cog):
         """
         if message.channel and isinstance(message.channel, discord.TextChannel) and message.channel.id == fifth_glyph_channel_id:
             for g in glyphs:
-                if g in message.content or any([True for a in message.attachments if g in a.filename]):
+                if g in message.content or g in emoji.demojize(message.content) or any([True for a in message.attachments if g in a.filename]):
                     logger.info(f"Deleted message {message.id}, contained verboten glyph '{g}', contents were '{message.content}'")
                     await message.delete()
 

--- a/cogs/fifth_glyph.py
+++ b/cogs/fifth_glyph.py
@@ -4,6 +4,7 @@ Fifth glyph is bad, ban at all costs.
 import discord
 from discord.ext import commands
 import emoji
+from random import randrange
 import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -14,7 +15,10 @@ logger.setLevel(logging.DEBUG)
 # testing channel ID
 fifth_glyph_channel_id = 820549897501540424
 
-glyphs = ['e', 'E', 'ꗋ', 'æ', 'Æ', 'œ', 'Œ', '€', '£', 'ⱻ', 'Ɇ', 'ɇ', 'Ə', 'ǝ', 'ⱸ', 'Ɛ', 'ℇ']
+glyphs = ['e', 'E', 'ꗋ', 'æ', 'Æ', 'œ', 'Œ', '€', '£', 'ⱻ', 'Ɇ', 'ɇ', 'Ə', 'ǝ', 'ⱸ', 'Ɛ', 'ℇ', '3']
+
+naughty = ['fuck', 'shit', 'fuckyou', 'fucku']
+responses = ['haha', 'stand down!', 'no', 'no u', ':P', 'huh.', '"it\'s my party and i\'ll cry if i want to"', 'say that 10x fast', 'quit slinging mud you rascal']
 
 class FifthGlyphCog(commands.Cog):
     def __init__(self, bot):
@@ -36,6 +40,9 @@ class FifthGlyphCog(commands.Cog):
         Audaciously cull the fifth glyph
         """
         if message.channel and isinstance(message.channel, discord.TextChannel) and message.channel.id == fifth_glyph_channel_id:
+            if "".join(message.content.split()).lower() in naughty:
+                # sass it up
+                await message.channel.send(responses[randrange(0, len(responses))])
             for g in glyphs:
                 if g in message.content or g in emoji.demojize(message.content) or any([True for a in message.attachments if g in a.filename]):
                     logger.info(f"Deleted message {message.id}, contained verboten glyph '{g}', contents were '{message.content}'")

--- a/cogs/fifth_glyph.py
+++ b/cogs/fifth_glyph.py
@@ -10,10 +10,10 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 # real channel ID
-# fifth_glyph_channel_id = 820535744035553290
+fifth_glyph_channel_id = 820535744035553290
 
 # testing channel ID
-fifth_glyph_channel_id = 820549897501540424
+# fifth_glyph_channel_id = 820549897501540424
 
 glyphs = ['e', 'E', 'ꗋ', 'æ', 'Æ', 'œ', 'Œ', '€', '£', 'ⱻ', 'Ɇ', 'ɇ', 'Ə', 'ǝ', 'ⱸ', 'Ɛ', 'ℇ', '3']
 

--- a/main.py
+++ b/main.py
@@ -63,7 +63,8 @@ default_extensions = ['cogs.basic',
                       'cogs.advent',
                       'cogs.hentai',
                       'cogs.garden',
-                      'cogs.aroundtheworld']
+                      'cogs.aroundtheworld',
+                      'cogs.fifth_glyph']
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ beautifulsoup4~=4.6.0
 pylint~=1.7.3
 aiohttp<3.6.0
 opencensus-ext-azure
+emoji


### PR DESCRIPTION
I play this game in a work server and it's surprisingly fun; figured it would be a good addition here.

A [non-standard module](https://pypi.org/project/emoji/) is used to convert Unicode characters to human-readable strings for additional yeeting [criteria](https://bit.ly/30Ewoy3), so you'll need to run `pip install reqs.txt` on the host machine.

I tested the cog using a locally running instance of the bot connected to a personal server, hence the channel IDs in the file. Feel free to squash the commits ~~if~~ when merging.

eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee e e