### PR TITLE
Add ">>gottem" alias for ">>webcam" command

### DIFF
--- a/cogs/basic.py
+++ b/cogs/basic.py
@@ -69,7 +69,7 @@ def generate_claps(message: str, emoji: str) -> str:
 def _test_example():
     """
     Example of how to incorporate doctests
-    
+
     >>> _test_example()
     'Pong!'
 
@@ -155,7 +155,7 @@ class BasicCog(commands.Cog):
         """
         encoded = urllib.parse.quote_plus(search)
         await ctx.send(f'Really!? How lazy are you? https://www.google.com/search?q={encoded}')
-    
+
     @commands.command(name=u"clap")
     @commands.cooldown(5, 10, commands.BucketType.user)
     async def clap(self, ctx, emoji, *, message):
@@ -172,12 +172,12 @@ class BasicCog(commands.Cog):
     @commands.cooldown(5, 10, commands.BucketType.user)
     async def clap_skin_tone_1(self, ctx, *, message):
         await ctx.send(generate_claps(message, u"\U0001F44F\U0001F3FB"))
-    
+
     @commands.command(name=u"\U0001F44F\U0001F3FC", hidden = True)
     @commands.cooldown(5, 10, commands.BucketType.user)
     async def clap_skin_tone_2(self, ctx, *, message):
         await ctx.send(generate_claps(message, u"\U0001F44F\U0001F3FC"))
-    
+
     @commands.command(name=u"\U0001F44F\U0001F3FD", hidden = True)
     @commands.cooldown(5, 10, commands.BucketType.user)
     async def clap_skin_tone_3(self, ctx, *, message):

--- a/cogs/basic.py
+++ b/cogs/basic.py
@@ -101,7 +101,7 @@ class BasicCog(commands.Cog):
     async def github(self, ctx):
         await ctx.send(f'https://github.com/Chris-Johnston/CSSBot_Py')
 
-    @commands.command(name='webcam')
+    @commands.command(name='webcam', aliases=['gottem'])
     async def webcam(self, ctx):
         if random.randint(1, 1000) == 420:
             await ctx.send("gottem")
@@ -113,10 +113,6 @@ class BasicCog(commands.Cog):
         r = requests.get(webcam_url)
         f = discord.File(BytesIO(r.content), filename=f"webcam{time.time()}.jpg")
         await ctx.send(file=f)
-
-    @commands.command(name='gottem')
-    async def gottem(self, ctx):
-        await self.webcam(ctx)
 
     @commands.command(name='405')
     async def i405(self, ctx):

--- a/cogs/basic.py
+++ b/cogs/basic.py
@@ -113,9 +113,9 @@ class BasicCog(commands.Cog):
         r = requests.get(webcam_url)
         f = discord.File(BytesIO(r.content), filename=f"webcam{time.time()}.jpg")
         await ctx.send(file=f)
-        
-    @commands.command(name='gotten')
-    async def gotten(self, ctx):
+
+    @commands.command(name='gottem')
+    async def gottem(self, ctx):
         await self.webcam(ctx)
 
     @commands.command(name='405')

--- a/cogs/basic.py
+++ b/cogs/basic.py
@@ -114,6 +114,10 @@ class BasicCog(commands.Cog):
         f = discord.File(BytesIO(r.content), filename=f"webcam{time.time()}.jpg")
         await ctx.send(file=f)
         
+    @commands.command(name='gotten')
+    async def gotten(self, ctx):
+        await self.webcam(ctx)
+
     @commands.command(name='405')
     async def i405(self, ctx):
         await ctx.send(f'https://images.wsdot.wa.gov/nw/405vc03022.jpg?t={time.time()}')


### PR DESCRIPTION
This PR adds an alias (`>>gottem`) for the popular `>>webcam` command.

Users on discord have been using the `:gottem:` emoji in conjunction with the `>>webcam` command. Thus, they want to be able to call the webcam functionality with the `>>gottem` moniker.

EDIT: Simplified the logic by using the [aliases decorator](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html?highlight=alias#discord.ext.commands.Command.aliases) from the SDK.